### PR TITLE
fix(upload): improve error handling for max file count

### DIFF
--- a/src/middlewares/upload.js
+++ b/src/middlewares/upload.js
@@ -82,11 +82,13 @@ export const uploadImages = ({ maxCount = 5 } = {}) => {
             case 'LIMIT_FILE_SIZE':
               message = '파일 용량은 1MB 이하만 가능합니다.';
               break;
-            case 'LIMIT_FILE_COUNT':
-              message = '최대 업로드 개수를 초과했습니다.';
-              break;
             case 'LIMIT_UNEXPECTED_FILE':
-              message = '허용되지 않는 파일 형식입니다.';
+              const photoFiles = req.files?.photos ?? [];
+              if (photoFiles.length >= (maxCount ?? 5)) {
+                message = '최대 업로드 개수를 초과했습니다.';
+              } else {
+                message = '허용되지 않는 파일이거나, 업로드 가능한 파일 개수를 초과했습니다.';
+              }
               break;
           }
 


### PR DESCRIPTION
fields에 대해서는 multer에서 파일 업로드 중 허용된 최대 파일 개수 초과 시에,
'LIMIT_FILE_COUNT'가 아닌 'LIMIT_UNEXPECTED_FILE' 에러를 반환하여, 에러 메시지를 swtich 내에서 수동으로 분기 처리하였습니다.

※ 참고: https://github.com/expressjs/multer/issues/602