### PR TITLE
feat(upload): add server-side image MIME type validation and cleanup …

### DIFF
--- a/frontend/.env.sample
+++ b/frontend/.env.sample
@@ -1,1 +1,1 @@
-NEXT_PUBLIC_API_URL=http://localhost:3001
+NEXT_PUBLIC_API_URL=http://localhost:3001/api

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "bcrypt": "^6.0.0",
         "cors": "^2.8.5",
         "cross-env": "^7.0.3",
-        "dayjs": "^1.11.13",
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "express-rate-limit": "^7.5.1",
@@ -614,12 +613,6 @@
       "engines": {
         "node": ">= 8"
       }
-    },
-    "node_modules/dayjs": {
-      "version": "1.11.13",
-      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.11.13.tgz",
-      "integrity": "sha512-oaMBel6gjolK862uaPQOVTA7q3TZhuSvuMQAAglQDOWYO9A91IrAOUJEyKVlqJlHE0vq5p5UXxzdPfMH/x6xNg==",
-      "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,6 +18,7 @@
         "dotenv": "^16.5.0",
         "express": "^5.1.0",
         "express-rate-limit": "^7.5.1",
+        "file-type": "^20.5.0",
         "helmet": "^8.1.0",
         "multer": "^2.0.1",
         "pg": "^8.16.2",
@@ -110,6 +111,30 @@
       "dependencies": {
         "@prisma/debug": "6.10.1"
       }
+    },
+    "node_modules/@tokenizer/inflate": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/@tokenizer/inflate/-/inflate-0.2.7.tgz",
+      "integrity": "sha512-MADQgmZT1eKjp06jpI2yozxaU9uVs4GzzgSL+uEq7bVcJ9V1ZXQkeGNql1fsSI0gMy1vhvNTNbUqrx+pZfJVmg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "^4.4.0",
+        "fflate": "^0.8.2",
+        "token-types": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
+    "node_modules/@tokenizer/token": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@tokenizer/token/-/token-0.3.0.tgz",
+      "integrity": "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A==",
+      "license": "MIT"
     },
     "node_modules/accepts": {
       "version": "2.0.0",
@@ -806,6 +831,30 @@
         "express": ">= 4.11"
       }
     },
+    "node_modules/fflate": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/fflate/-/fflate-0.8.2.tgz",
+      "integrity": "sha512-cPJU47OaAoCbg0pBvzsgpTPhmhqI5eJjh/JIu8tPj5q+T7iLvW/JAYUqmE7KOB4R1ZyEhzBaIQpQpardBF5z8A==",
+      "license": "MIT"
+    },
+    "node_modules/file-type": {
+      "version": "20.5.0",
+      "resolved": "https://registry.npmjs.org/file-type/-/file-type-20.5.0.tgz",
+      "integrity": "sha512-BfHZtG/l9iMm4Ecianu7P8HRD2tBHLtjXinm4X62XBOYzi7CYA7jyqfJzOvXHqzVrVPYqBo2/GvbARMaaJkKVg==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/inflate": "^0.2.6",
+        "strtok3": "^10.2.0",
+        "token-types": "^6.0.0",
+        "uint8array-extras": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/file-type?sponsor=1"
+      }
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -1101,6 +1150,26 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
     },
     "node_modules/ignore-by-default": {
       "version": "1.0.1",
@@ -2057,6 +2126,22 @@
         "node": ">=8"
       }
     },
+    "node_modules/strtok3": {
+      "version": "10.3.1",
+      "resolved": "https://registry.npmjs.org/strtok3/-/strtok3-10.3.1.tgz",
+      "integrity": "sha512-3JWEZM6mfix/GCJBBUrkA8p2Id2pBkyTkVCJKto55w080QBKZ+8R171fGrbiSp+yMO/u6F8/yUh7K4V9K+YCnw==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
+      }
+    },
     "node_modules/superstruct": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/superstruct/-/superstruct-2.0.2.tgz",
@@ -2099,6 +2184,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.6"
+      }
+    },
+    "node_modules/token-types": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/token-types/-/token-types-6.0.3.tgz",
+      "integrity": "sha512-IKJ6EzuPPWtKtEIEPpIdXv9j5j2LGJEYk0CKY2efgKoYKLBiZdh6iQkLVBow/CB3phyWAWCyk+bZeaimJn6uRQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@tokenizer/token": "^0.3.0",
+        "ieee754": "^1.2.1"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Borewit"
       }
     },
     "node_modules/touch": {
@@ -2161,6 +2263,18 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "node_modules/uint8array-extras": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/uint8array-extras/-/uint8array-extras-1.4.0.tgz",
+      "integrity": "sha512-ZPtzy0hu4cZjv3z5NW9gfKnNLjoz4y6uv4HlelAjDK7sY/xOkKZv9xK/WQpcsBB3jEybChz9DPC2U/+cusjJVQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/undefsafe": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "express-rate-limit": "^7.5.1",
+    "file-type": "^20.5.0",
     "helmet": "^8.1.0",
     "multer": "^2.0.1",
     "pg": "^8.16.2",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
     "bcrypt": "^6.0.0",
     "cors": "^2.8.5",
     "cross-env": "^7.0.3",
-    "dayjs": "^1.11.13",
     "dotenv": "^16.5.0",
     "express": "^5.1.0",
     "express-rate-limit": "^7.5.1",

--- a/src/controllers/uploadController.js
+++ b/src/controllers/uploadController.js
@@ -1,13 +1,15 @@
-import { fromFile } from 'file-type';
+import { fileTypeFromFile } from 'file-type';
 import fs from 'fs/promises';
 
 /**
- * 여러 이미지 파일 업로드를 처리합니다.
+ * upload 미들웨어에서 이미 서버에 저장된 이미지 파일들에 대해
+ * 실제 이미지 포맷 여부를 검증하고, 비정상 파일을 삭제합니다.
  * 
  * 1. 업로드된 파일이 없으면 400 반환
- * 2. 업로드된 각 파일에 대해 file-type으로 실제 이미지 포맷 여부를 검증합니다.
- *    - 허용된 이미지 포맷이 아닌 경우 즉시 삭제 및 업로드 전체 거부
- * 3. 모든 파일이 정상 이미지일 경우 업로드 URL을 반환합니다.
+ * 2. 각 파일에 대해 file-type으로 실제 이미지 포맷 여부를 검증합니다.
+ *    - 허용된 이미지 포맷이 아닌 경우 즉시 삭제 및 정상 파일만 남김
+ * 3. 모든 파일이 정상 이미지면 파일 URL 반환
+ * 비정상 파일이 있으면 전체 파일 삭제 후 400 반환
  * 
  * @param {import('express').Request} req - Express 요청 객체
  * @param {import('express').Response} res - Express 응답 객체
@@ -26,21 +28,24 @@ const uploadImage = async (req, res) => {
     });
   }
 
-  const allowedMimeTypes = ['image/jpeg', 'image/png', 'image/jpg', 'image/webp'];
-  const invalidFiles = [];
+  const allowedMimeTypes = ['image/jpeg', 'image/png', 'image/webp'];
+  let allValid = true;
 
   for (const file of files) {
-    const fileType = await fromFile(file.path);
+    const fileType = await fileTypeFromFile(file.path);
     if (!fileType || !allowedMimeTypes.includes(fileType.mime)) {
-      await fs.unlink(file.path).catch(() => {});
-      invalidFiles.push(file.originalname);
+      allValid = false;
+      break;
     }
   }
 
-  if (invalidFiles.length > 0) {
+  if (!allValid) {
+    for (const file of files) {
+      await fs.unlink(file.path).catch(() => {});
+    }
     return res.status(400).json({
       success: false,
-      message: `지원하지 않는 이미지 형식입니다: ${invalidFiles.join(', ')}`,
+      message: '허용되지 않는 파일이 포함되어 있어 업로드가 거부되었습니다.',
     });
   }
 

--- a/src/controllers/uploadController.js
+++ b/src/controllers/uploadController.js
@@ -1,4 +1,19 @@
-const uploadImage = (req, res) => {
+import { fromFile } from 'file-type';
+import fs from 'fs/promises';
+
+/**
+ * 여러 이미지 파일 업로드를 처리합니다.
+ * 
+ * 1. 업로드된 파일이 없으면 400 반환
+ * 2. 업로드된 각 파일에 대해 file-type으로 실제 이미지 포맷 여부를 검증합니다.
+ *    - 허용된 이미지 포맷이 아닌 경우 즉시 삭제 및 업로드 전체 거부
+ * 3. 모든 파일이 정상 이미지일 경우 업로드 URL을 반환합니다.
+ * 
+ * @param {import('express').Request} req - Express 요청 객체
+ * @param {import('express').Response} res - Express 응답 객체
+ * @returns {Promise<void>}
+ */
+const uploadImage = async (req, res) => {
   const files = [
     ...(req.files?.photos || []),
     ...(req.files?.photoUrl || []),
@@ -8,6 +23,24 @@ const uploadImage = (req, res) => {
     return res.status(400).json({
       success: false,
       message: '업로드된 파일이 없습니다.',
+    });
+  }
+
+  const allowedMimeTypes = ['image/jpeg', 'image/png', 'image/jpg', 'image/webp'];
+  const invalidFiles = [];
+
+  for (const file of files) {
+    const fileType = await fromFile(file.path);
+    if (!fileType || !allowedMimeTypes.includes(fileType.mime)) {
+      await fs.unlink(file.path).catch(() => {});
+      invalidFiles.push(file.originalname);
+    }
+  }
+
+  if (invalidFiles.length > 0) {
+    return res.status(400).json({
+      success: false,
+      message: `지원하지 않는 이미지 형식입니다: ${invalidFiles.join(', ')}`,
     });
   }
 

--- a/src/middlewares/upload.js
+++ b/src/middlewares/upload.js
@@ -55,7 +55,7 @@ export const uploadImages = ({ maxCount = 5 } = {}) => {
   });
 
   const fileFilter = (req, file, cb) => {
-    const allowedTypes = ['image/jpeg', 'image/png', 'image/jpg', 'image/webp'];
+    const allowedTypes = ['image/jpeg', 'image/png', 'image/webp'];
     if (allowedTypes.includes(file.mimetype)) {
       cb(null, true);
     } else {


### PR DESCRIPTION
## 주요 변경 사항
- 업로드된 파일의 실제 타입(MIME type)을 `file-type` 패키지로 검증하도록 추가했습니다.
- 업로드 된 파일 중 하나라도 허용된 이미지 포맷(jpeg, png, webp)이 아닐 경우, 서버에서 해당 파일을 삭제하고 400 에러와 함께 에러 메시지를 반환합니다.

## 추가 변경사항
- 기존 `upload` 미들웨어에서 `jpg` 타입도 허용했는데, 찾아보니 표준 타입에는 `jpeg`만 있어 수정했습니다.
- frontend `.env.sample`에 `/api` 문구를 axios.ts의 BASE_URL에 대응하도록 추가했습니다.

## 참고 사항
- `file-type` 패키지 설치가 필요합니다.
- 로컬 환경에서 테스트 시에 프론트 쪽 `.env` 수정이 필요합니다.
- 이미지처럼 보이는 일부 zip(폴리글롯) 파일은 file-type 검사를 통과할 수 있으나, 업로드 용량 제한(1MB)으로 인해 실질적 위협 가능성은 낮고, 이를 완전히 차단하려면 파일 재인코딩 과정이 필요해 현재 프로젝트 범위에서는 제외했습니다.
- `dayjs`가 불필요한 패키지로 남아있어 삭제했습니다.