### PR TITLE
Increase image upload limit from 3 to 5 (handled on frontend)

### DIFF
--- a/frontend/app/groups/[groupId]/records/components/RecordForm.tsx
+++ b/frontend/app/groups/[groupId]/records/components/RecordForm.tsx
@@ -86,10 +86,10 @@ const RecordForm = ({
           <Label htmlFor="photos">사진</Label>
           <ImageInput
             className={cx('photosInput')}
-            maxCount={3}
-            values={watch('photos')?.map(encodeImageUrl) ?? []} // 인코딩 적용
+            maxCount={5}
+            values={watch('photos')?.map(encodeImageUrl) ?? []}
             onChange={(urls) => {
-              setValue('photos', urls); // 저장은 원본 URL로
+              setValue('photos', urls);
             }}
           />
         </div>

--- a/frontend/app/groups/components/GroupForm.tsx
+++ b/frontend/app/groups/components/GroupForm.tsx
@@ -126,7 +126,7 @@ const GroupForm = ({
             </Label>
             <ImageInput
               className={cx('thumbnailInput')}
-              values={values.photoUrl ? [encodeImageUrl(values.photoUrl)] : []} // 인코딩 추가
+              values={values.photoUrl ? [encodeImageUrl(values.photoUrl)] : []}
               onChange={(values: string[]) => {
                 setValue('photoUrl', values[0]);
               }}

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -26,8 +26,7 @@ const logError = (error: unknown) => {
     const response = error.response;
     if (response) {
       console.error(
-        `[프론트] ${response.config.method?.toUpperCase()} ${
-          response.config.url
+        `[프론트] ${response.config.method?.toUpperCase()} ${response.config.url
         } ${response.status}`
       );
       console.error(response.data);

--- a/src/app.js
+++ b/src/app.js
@@ -37,13 +37,12 @@ const FRONT_ORIGIN = isProd
 
 const allowedOrigins = [FRONT_ORIGIN];
 const currentImageHost = `${BASE_URL}/api/files`;
-const PROXY_OPTION = isProd ? true : 1;
 
 // 서버 초기화
 const app = express();
 
 // 프록시 신뢰 설정 (Cloudflare 등)
-app.set('trust proxy', PROXY_OPTION);
+app.set('trust proxy', 1);
 
 // 앱 전역 변수 설정
 app.locals.BASE_URL = BASE_URL;

--- a/src/middlewares/upload.js
+++ b/src/middlewares/upload.js
@@ -83,12 +83,7 @@ export const uploadImages = ({ maxCount = 5 } = {}) => {
               message = '파일 용량은 1MB 이하만 가능합니다.';
               break;
             case 'LIMIT_UNEXPECTED_FILE':
-              const photoFiles = req.files?.photos ?? [];
-              if (photoFiles.length >= maxCount) {
-                message = '최대 업로드 개수를 초과했습니다.';
-              } else {
-                message = '허용되지 않는 파일이거나, 업로드 가능한 개수를 초과했습니다.';
-              }
+              message = '허용되지 않는 파일 형식입니다.';
               break;
           }
 


### PR DESCRIPTION
## 주요 변경 사항

- 이미지 업로드 최대 개수를 **3개 → 5개**로 상향 조정했습니다.
- 업로드 개수 제한은 **프론트엔드에서 처리되도록 변경**했습니다.
- 서버는 초과된 파일을 자동으로 무시하도록 기존 로직을 유지합니다.